### PR TITLE
Silence Xonsh foreign alias application warning

### DIFF
--- a/.xonshrc
+++ b/.xonshrc
@@ -4,6 +4,10 @@ xontrib load vox
 
 source-bash ~/.bash_profile
 
+# Disable alias warning:
+#    Skipping application of 'foo' alias from 'bash' [...]
+$FOREIGN_ALIASES_SUPPRESS_SKIP_MESSAGE = True
+
 # Customize multiline prompt appearance
 $MULTILINE_PROMPT = '`·.,¸,.·*¯`·.,¸,.·*¯'
 


### PR DESCRIPTION
Through the `$FOREIGN_ALIASES_SUPPRESS_SKIP_MESSAGE` env variable.

This variable was added in [Xonsh 0.7.9](https://github.com/xonsh/xonsh/releases/tag/0.7.9)